### PR TITLE
Fix application startup and dev-docker-compsoe

### DIFF
--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -1,4 +1,4 @@
-dversion: '3'
+version: '3'
 services:
   fortune-app-backend:
     image: thiagotr/fortune-backend
@@ -9,7 +9,7 @@ services:
 
   fortune-scrapper:
     build: .
-    restart_policy: always
+    restart: always
     environment:
       ENABLE_CRON: 'true'
       CRON_INTERVAL: 10s


### PR DESCRIPTION
If merged the following will be fixed:

- Typo at the docker-composes version declaration
- Restart policy flag
- Application startup doesn't do a full sync every `CRON_INTERVAL` anymore.